### PR TITLE
Add immersive homepage theme carousel

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -52,6 +52,60 @@ final result: passed
 
 ---
 
+# 官网首页 Hero「流光沉浸」Design QA
+
+## Source visual truth
+
+- 用户选定方案 1：`/Users/canghe/responsibility/canghe/codex-themes/.cowork-temp/home-hero-direction-1.png`。
+- 目标结构：黑金官网首屏、左侧三行高对比标题、主题主图铺满首屏、右侧三层主题卡组、缩略图轨道与主题进度。
+- 目标行为：背景与当前轮播主题同步；主题有独立 `hero.png`／`wallpaper.png` 时使用无 UI 高清主图，否则使用经过弱化处理的真实预览图。
+
+## Implementation evidence
+
+- 桌面最终截图：`/Users/canghe/responsibility/canghe/codex-themes/.cowork-temp/home-hero-implementation-final.png`。
+- 移动端最终截图：`/Users/canghe/responsibility/canghe/codex-themes/.cowork-temp/home-hero-mobile-final.png`。
+- 最终全图并排对照：`/Users/canghe/responsibility/canghe/codex-themes/.cowork-temp/home-hero-qa-final.png`。
+- 标题、操作与轮播焦点对照：`/Users/canghe/responsibility/canghe/codex-themes/.cowork-temp/home-hero-qa-focus.png`。
+- 桌面测试视口：1440 × 1000 CSS px，截图栅格 1440 × 964 px；移动端测试视口：390 × 844 CSS px，截图栅格 390 × 823 px。
+- 状态：首屏、自动播放、手动下一张、主题主图联动、移动端单列。
+
+## Findings
+
+- No actionable P0/P1/P2 visual findings remain.
+- Fonts and typography：沿用官网现有无衬线字体与暖白／蜂蜜金层级；标题保持三行、无孤字和裁切，辅助文案、CTA 与安全说明的字重和对比清晰。
+- Spacing and layout rhythm：桌面端左侧标题上移到参考稿的视觉高度，右侧主卡和缩略图保持原有三层景深；主题名与 `01 / 08` 完整留在首屏内。390px 下改为标题、操作、卡组的纵向顺序，无水平溢出。
+- Colors and visual tokens：背景采用深蓝月夜、暖黑遮罩和金色操作色；左侧使用由密到疏的黑色遮罩形成稳定文字安全区，右侧保留足够图像亮度和卡片边界。
+- Image quality and asset fidelity：背景优先复用主题包真实无 UI 主图，并通过 Astro 输出响应式 WebP；没有将带控件的主题预览硬铺成背景。没有独立主图的主题使用真实预览图回退，并增加轻度模糊与压暗以避免背景文字干扰。
+- Copy and content：主标题、说明、CTA、安全说明、主题名与计数均保持真实可编辑文本；中英文路由继续共用同一组件。
+- Icons and controls：继续使用项目现有 Lucide 图标；前后按钮、卡片、缩略图和 CTA 保持原生按钮／链接语义。
+- Accessibility：缩略图保持 radio group 与 `aria-checked`，当前卡片、当前背景和计数只存在一个选中状态；减少动态效果偏好下不启动自动播放。
+
+## Interaction and runtime verification
+
+- 手动点击“下一个主题”后，计数从 `01 / 08` 更新为 `02 / 08`，主题名切换为“七秀镜湖”，选中缩略图与背景图同步更新。
+- 自动播放会更新当前主题和背景；指针停留、键盘焦点进入、页面隐藏时继续沿用现有暂停逻辑。
+- 轮播初始化增加幂等标记，避免开发热更新重复注册监听器或计时器。
+- 桌面端与移动端均只有一个活动背景、一个选中缩略图和三张可见景深卡片。
+- 浏览器控制台无 error／warning；页面无横向溢出。
+- TypeScript/Astro 类型检查、网站生产构建和 `git diff --check` 通过。
+
+## Comparison history
+
+1. 第一轮把主题主图接入全屏背景并同步轮播，但并排对照发现左侧图像过暗、标题整体偏低、底部主题计数接近首屏裁切边缘（P2）。
+2. 放宽左侧遮罩、提高主图亮度和饱和度，将标题按参考图上移，并缩短主题舞台高度，让缩略图、主题名与计数完整进入首屏。
+3. 第二轮桌面截图确认三行标题、主操作和右侧卡组与参考稿层级一致；390px 截图确认文字安全区、CTA、卡组与主题背景均正常，无横向溢出。
+4. 最终并排与焦点对照确认核心视觉方向一致。参考图中的左下人物位置是生成稿构图，实装保留官方主题主图的原始人物位置并让其进入右侧卡组之后，属于保证主题资产真实性的有意差异。
+
+## Follow-up polish
+
+- [P3] 后续可为目前只有 `preview.png` 的主题补齐独立无 UI `hero.png`，使所有轮播背景都达到“曜月谪仙／山海灵境”同等级的沉浸感。
+
+## Final result
+
+final result: passed
+
+---
+
 # 官网 Banner「主题背景＋右侧轮播」Design QA
 
 ## Source visual truth

--- a/web/src/components/HomePage.astro
+++ b/web/src/components/HomePage.astro
@@ -9,13 +9,22 @@ import { themes } from "../lib/themes";
 
 const { locale } = Astro.props as { locale: Locale };
 const t = copy[locale];
-const heroThemeIds = ["mirror-lake-ribbon", "moonlit-immortal", "neon-star-hunter"];
+const heroThemeIds = [
+  "moonlit-immortal",
+  "mirror-lake-ribbon",
+  "starcap-teemo",
+  "shanhai-nexus",
+  "neon-star-hunter",
+  "mecha-cat-studio",
+  "potion-workshop",
+  "focus-capybara",
+];
 const heroThemes = heroThemeIds.map((id) => {
   const theme = themes.find((item) => item.id === id);
   if (!theme) throw new Error(`Missing home hero theme: ${id}`);
   return localizeTheme(theme, locale);
 });
-const featured = themes.slice(0, 6);
+const featured = themes.slice(0, 12);
 const description =
   locale === "zh"
     ? "从官方主题到本地 AI 生成，一键应用，也能随时恢复。"
@@ -29,12 +38,15 @@ const description =
         <Image
           class="home-theme-backdrop-image"
           data-backdrop-index={index}
-          src={theme.preview}
+          data-active={index === 0 ? "true" : "false"}
+          data-backdrop-kind={theme.hasBackdropArtwork ? "artwork" : "preview"}
+          src={theme.backdrop}
           alt=""
-          widths={[420, 680]}
-          sizes="(max-width: 820px) 58vw, 24vw"
+          widths={[960, 1440, 1920]}
+          sizes="100vw"
           format="webp"
           loading={index === 0 ? "eager" : "lazy"}
+          style={`object-position: ${theme.backdropFocus.x * 100}% ${theme.backdropFocus.y * 100}%`}
         />
       ))}
     </div>
@@ -69,7 +81,10 @@ const description =
               type="button"
               data-carousel-card
               data-theme-index={index}
-              data-depth={index}
+              data-depth={index < 3 ? index : "hidden"}
+              aria-hidden={index < 3 ? "false" : "true"}
+              aria-pressed={index === 0 ? "true" : "false"}
+              tabindex={index < 3 ? 0 : -1}
               aria-label={`${locale === "zh" ? "预览" : "Preview"} ${theme.name}`}
             >
               <Image
@@ -116,7 +131,7 @@ const description =
           </div>
           <div class="home-rail-meta" aria-live="polite">
             <strong data-carousel-name>{heroThemes[0].name.replace(/\s+[A-Z][\s\S]*$/, "")}</strong>
-            <span data-carousel-count>01 / 03</span>
+            <span data-carousel-count>01 / {String(heroThemes.length).padStart(2, "0")}</span>
             <div class="home-rail-progress" aria-hidden="true"><i data-carousel-progress></i></div>
           </div>
         </div>
@@ -228,8 +243,12 @@ const description =
 
   <script>
     document.querySelectorAll<HTMLElement>("[data-home-carousel]").forEach((carousel) => {
+      if (carousel.dataset.carouselReady === "true") return;
+      carousel.dataset.carouselReady = "true";
+
       const cards = Array.from(carousel.querySelectorAll<HTMLButtonElement>("[data-carousel-card]"));
       const thumbs = Array.from(carousel.querySelectorAll<HTMLButtonElement>("[data-carousel-thumb]"));
+      const backdrops = Array.from(carousel.querySelectorAll<HTMLElement>("[data-backdrop-index]"));
       const stage = carousel.querySelector<HTMLElement>(".home-theme-stage");
       const name = carousel.querySelector<HTMLElement>("[data-carousel-name]");
       const count = carousel.querySelector<HTMLElement>("[data-carousel-count]");
@@ -241,15 +260,30 @@ const description =
       const select = (next: number) => {
         selected = (next + cards.length) % cards.length;
         cards.forEach((card, index) => {
-          card.dataset.depth = String((index - selected + cards.length) % cards.length);
+          const depth = (index - selected + cards.length) % cards.length;
+          const visible = depth < 3;
+          card.dataset.depth = visible ? String(depth) : "hidden";
           card.setAttribute("aria-pressed", String(index === selected));
+          card.setAttribute("aria-hidden", String(!visible));
+          card.tabIndex = visible ? 0 : -1;
         });
         thumbs.forEach((thumb, index) => {
           thumb.setAttribute("aria-checked", String(index === selected));
         });
+        backdrops.forEach((backdrop, index) => {
+          backdrop.dataset.active = String(index === selected);
+        });
         if (name) name.textContent = thumbs[selected]?.dataset.themeName ?? "";
         if (count) count.textContent = `${String(selected + 1).padStart(2, "0")} / ${String(cards.length).padStart(2, "0")}`;
         if (progress) progress.style.transform = `scaleX(${(selected + 1) / cards.length})`;
+        const activeThumb = thumbs[selected];
+        const thumbnailRail = activeThumb?.parentElement;
+        if (activeThumb && thumbnailRail) {
+          thumbnailRail.scrollTo({
+            left: activeThumb.offsetLeft - (thumbnailRail.clientWidth - activeThumb.clientWidth) / 2,
+            behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+          });
+        }
       };
 
       const stopAutoplay = () => {

--- a/web/src/lib/themes.ts
+++ b/web/src/lib/themes.ts
@@ -8,6 +8,9 @@ interface ThemeManifest {
   version: string;
   tags?: string[];
   layout: string;
+  wallpaper?: string;
+  wallpaperFocusX?: number;
+  wallpaperFocusY?: number;
 }
 
 export interface WebTheme {
@@ -19,6 +22,9 @@ export interface WebTheme {
   tags: string[];
   layout: string;
   preview: ImageMetadata;
+  backdrop: ImageMetadata;
+  backdropFocus: { x: number; y: number };
+  hasBackdropArtwork: boolean;
   deepLink: string;
 }
 
@@ -32,6 +38,16 @@ const previewModules = import.meta.glob<{ default: ImageMetadata }>(
   { eager: true },
 );
 
+const heroModules = import.meta.glob<{ default: ImageMetadata }>(
+  "../../../assets/presets/*/hero.png",
+  { eager: true },
+);
+
+const wallpaperModules = import.meta.glob<{ default: ImageMetadata }>(
+  "../../../assets/presets/*/wallpaper.png",
+  { eager: true },
+);
+
 function themeIdFromPath(file: string): string | null {
   return file.match(/\/assets\/presets\/([^/]+)\//)?.[1] ?? null;
 }
@@ -42,6 +58,14 @@ const previewById = new Map(
     .filter((entry): entry is [string, ImageMetadata] => Boolean(entry[0])),
 );
 
+const backdropByPath = new Map(
+  Object.entries({ ...heroModules, ...wallpaperModules }).map(([file, module]) => {
+    const id = themeIdFromPath(file);
+    const filename = file.split("/").at(-1);
+    return [`${id}/${filename}`, module.default] as const;
+  }),
+);
+
 export const themes: WebTheme[] = Object.entries(manifestModules)
   .map(([file, module]) => {
     const folderId = themeIdFromPath(file);
@@ -50,6 +74,8 @@ export const themes: WebTheme[] = Object.entries(manifestModules)
     if (!folderId || manifest.id !== folderId || !preview) {
       throw new Error(`Invalid web theme source: ${file}`);
     }
+    const backdropFilename = manifest.wallpaper ?? "hero.png";
+    const backdropArtwork = backdropByPath.get(`${folderId}/${backdropFilename}`);
     return {
       id: manifest.id,
       name: manifest.name,
@@ -59,6 +85,12 @@ export const themes: WebTheme[] = Object.entries(manifestModules)
       tags: manifest.tags ?? [],
       layout: manifest.layout,
       preview,
+      backdrop: backdropArtwork ?? preview,
+      backdropFocus: {
+        x: manifest.wallpaperFocusX ?? 0.5,
+        y: manifest.wallpaperFocusY ?? 0.5,
+      },
+      hasBackdropArtwork: Boolean(backdropArtwork),
       deepLink: `codexthemes://theme/${encodeURIComponent(manifest.id)}`,
     };
   })

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -426,55 +426,51 @@ h3 {
 .home-theme-backdrop {
   position: absolute;
   z-index: 0;
-  bottom: 12%;
-  left: 0;
-  width: 49%;
-  height: 45%;
+  inset: 0;
   overflow: hidden;
-  opacity: 0.62;
-  filter: saturate(0.94) brightness(0.7);
-  mask-image: linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 0.66) 24%, #000 58%, rgba(0, 0, 0, 0.7) 100%);
+  opacity: 1;
   pointer-events: none;
 }
 
 .home-theme-backdrop::after {
   position: absolute;
+  z-index: 3;
   inset: 0;
   content: "";
   background:
-    linear-gradient(90deg, transparent 56%, #080907 100%),
-    linear-gradient(0deg, rgba(8, 9, 7, 0.08), #080907 100%);
+    linear-gradient(90deg, rgba(4, 9, 20, 0.5) 0%, rgba(4, 9, 20, 0.38) 24%, rgba(4, 9, 20, 0.14) 48%, rgba(4, 9, 20, 0.02) 72%),
+    linear-gradient(180deg, rgba(4, 9, 20, 0.2) 0%, transparent 22%, transparent 76%, rgba(4, 9, 20, 0.42) 100%);
 }
 
 .home-theme-backdrop-image {
   position: absolute;
-  bottom: -5%;
-  width: 45%;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   max-width: none;
-  aspect-ratio: 1.42;
-  border: 1px solid rgba(232, 187, 104, 0.24);
-  border-radius: 5px;
+  border: 0;
+  border-radius: 0;
   object-fit: cover;
-  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.68);
+  opacity: 0;
+  filter: saturate(1.08) brightness(0.92) contrast(1.02);
+  transform: scale(1.035);
+  transition: opacity 820ms ease, transform 6s cubic-bezier(0.22, 1, 0.36, 1), filter 820ms ease;
 }
 
-.home-theme-backdrop-image[data-backdrop-index="0"] {
+.home-theme-backdrop-image[data-backdrop-kind="preview"] {
+  filter: blur(4px) saturate(0.92) brightness(0.72);
+  transform: scale(1.075);
+}
+
+.home-theme-backdrop-image[data-active="true"] {
   z-index: 2;
-  left: -8%;
-  transform: rotate(-3deg);
+  opacity: 1;
+  transform: scale(1.01);
 }
 
-.home-theme-backdrop-image[data-backdrop-index="1"] {
-  z-index: 3;
-  left: 27%;
-  bottom: 1%;
-  transform: rotate(1.6deg);
-}
-
-.home-theme-backdrop-image[data-backdrop-index="2"] {
-  z-index: 1;
-  right: -4%;
-  transform: rotate(3deg);
+.home-theme-backdrop-image[data-active="true"][data-backdrop-kind="preview"] {
+  opacity: 0.82;
+  transform: scale(1.055);
 }
 
 .home-hero-main {
@@ -491,6 +487,8 @@ h3 {
   position: relative;
   z-index: 5;
   max-width: 610px;
+  align-self: start;
+  padding-top: clamp(52px, 6vh, 72px);
 }
 
 .home-hero-copy h1 {
@@ -501,6 +499,7 @@ h3 {
   font-weight: 720;
   letter-spacing: -0.065em;
   line-height: 1.27;
+  text-shadow: 0 2px 22px rgba(0, 0, 0, 0.72), 0 1px 3px rgba(0, 0, 0, 0.74);
 }
 
 .home-hero-copy h1 em {
@@ -512,9 +511,10 @@ h3 {
 .home-hero-copy > p {
   max-width: 560px;
   margin: 27px 0 28px;
-  color: rgba(244, 240, 233, 0.68);
+  color: rgba(248, 246, 241, 0.84);
   font-size: 18px;
   line-height: 1.75;
+  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.78);
 }
 
 .home-hero-actions {
@@ -588,7 +588,7 @@ h3 {
 .home-theme-stage {
   position: relative;
   min-width: 0;
-  min-height: 560px;
+  min-height: 495px;
   perspective: 1700px;
   touch-action: pan-y;
   user-select: none;
@@ -648,6 +648,16 @@ h3 {
   transform: translate3d(0, -47%, -90px) rotateY(-8deg) scale(0.9);
 }
 
+.home-deck-card[data-depth="hidden"] {
+  z-index: 0;
+  left: 46%;
+  width: 62%;
+  opacity: 0;
+  filter: saturate(0.6) brightness(0.55);
+  pointer-events: none;
+  transform: translate3d(0, -46%, -140px) rotateY(-10deg) scale(0.86);
+}
+
 .home-deck-card:hover,
 .home-deck-card:focus-visible {
   filter: saturate(1) brightness(1);
@@ -697,10 +707,15 @@ h3 {
 }
 
 .home-rail-thumbnails {
-  display: grid;
-  width: min(56%, 360px);
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  width: min(76%, 470px);
+  overflow-x: auto;
+  padding: 4px 3px 9px;
   gap: 10px;
+  scroll-behavior: smooth;
+  scroll-snap-type: x proximity;
+  scrollbar-color: rgba(223, 184, 102, 0.36) transparent;
+  scrollbar-width: thin;
 }
 
 .home-rail-thumbnail {
@@ -711,6 +726,8 @@ h3 {
   border-radius: 7px;
   background: #11120f;
   cursor: pointer;
+  flex: 0 0 72px;
+  scroll-snap-align: center;
   transition: border-color 180ms ease, opacity 180ms ease, transform 180ms ease;
 }
 
@@ -781,7 +798,7 @@ h3 {
   width: 100%;
   height: 100%;
   background: #dfb866;
-  transform: scaleX(0.3333);
+  transform: scaleX(0.125);
   transform-origin: left center;
   transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -1528,8 +1545,8 @@ h3 {
   }
 
   .home-theme-backdrop {
-    width: 55%;
-    height: 42%;
+    width: auto;
+    height: auto;
   }
 
   .home-hero-copy h1 {
@@ -1537,7 +1554,7 @@ h3 {
   }
 
   .home-theme-stage {
-    min-height: 530px;
+    min-height: 480px;
   }
 
   .home-theme-rail {
@@ -1644,10 +1661,16 @@ h3 {
   }
 
   .home-theme-backdrop {
-    bottom: 2%;
-    width: 100%;
-    height: 30%;
-    opacity: 0.3;
+    inset: 0;
+    width: auto;
+    height: auto;
+    opacity: 0.94;
+  }
+
+  .home-theme-backdrop::after {
+    background:
+      linear-gradient(180deg, rgba(4, 9, 20, 0.4) 0%, rgba(4, 9, 20, 0.28) 28%, rgba(4, 9, 20, 0.08) 58%, rgba(4, 9, 20, 0.5) 100%),
+      linear-gradient(90deg, rgba(4, 9, 20, 0.5), rgba(4, 9, 20, 0.06));
   }
 
   .home-hero-main {
@@ -1659,6 +1682,8 @@ h3 {
 
   .home-hero-copy {
     max-width: 680px;
+    align-self: auto;
+    padding-top: 0;
   }
 
   .home-hero-copy h1 {


### PR DESCRIPTION
## What changed

- expand the homepage hero carousel from three to eight official themes
- synchronize the active theme card, thumbnail, label, progress, and full-bleed theme artwork
- use real `hero.png` or `wallpaper.png` assets when available, with a preview fallback
- brighten the backdrop and constrain dark overlays to the copy area so the artwork remains visible
- expand the homepage gallery to twelve official themes

## Why

The homepage needed a stronger product showcase and a clearly visible theme image behind the workspace headline. The previous treatment either had too few examples or obscured the backdrop with a full-screen dark overlay.

## Impact

Visitors can now browse more themes directly in the hero and see each theme's artwork carried into the page background while retaining readable copy and accessible carousel controls.

## Validation

- `npm run typecheck`
- `npm run build:web`
- `git diff --check`
- desktop and mobile visual QA
- manual carousel synchronization check