### PR TITLE
Update workspace headline

### DIFF
--- a/web/src/components/HomePage.astro
+++ b/web/src/components/HomePage.astro
@@ -144,8 +144,8 @@ const description =
     <div class="manifesto-grid">
       <h2>
         {locale === "zh"
-          ? "主题不只是换张背景图，而是重新组织你的工作空间。"
-          : "A theme is more than a wallpaper. It reshapes the workspace around your work."}
+          ? "你的工作空间，也应该拥有自己的性格。"
+          : "Your workspace should have a personality of its own."}
       </h2>
       <p>
         {locale === "zh"


### PR DESCRIPTION
## What changed

- replace the homepage manifesto headline in Chinese
- update the English translation to match the new message

## Why

The previous copy used a contrast structure that no longer matched the desired editorial tone. The new headline gives the workspace a clearer sense of identity and personality.

## Impact

Homepage visitors see the new copy in both Chinese and English. No behavior or layout changes are included.

## Validation

- `npm run typecheck`
- `git diff --check`