### PR TITLE
Fix Codex DOM theme application

### DIFF
--- a/assets/inject/dream-skin.css
+++ b/assets/inject/dream-skin.css
@@ -736,6 +736,21 @@ html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.
   backdrop-filter: none !important;
 }
 
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock,
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock::before,
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock::after {
+  border-color: transparent !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+}
+
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock::before,
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock::after {
+  content: none !important;
+  display: none !important;
+}
+
 .dream-skin-home div:has(> .horizontal-scroll-fade-mask .group\/project-selector) {
   position: relative;
   padding-top: 28px !important;
@@ -3571,11 +3586,20 @@ html.codex-dream-skin[data-dream-theme="focus-capybara"] :is(main.main-surface, 
 
 html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .dream-skin-composer-dock:not(.dream-skin-composer),
 html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .dream-skin-composer-dock:not(.dream-skin-composer)::before,
-html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .dream-skin-composer-dock:not(.dream-skin-composer)::after {
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .dream-skin-composer-dock:not(.dream-skin-composer)::after,
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock,
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock::before,
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock::after {
   border-color: transparent !important;
   background: transparent !important;
   box-shadow: none !important;
   backdrop-filter: none !important;
+}
+
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock::before,
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="_ComposerLayoutRoot_"].dream-skin-composer-dock::after {
+  content: none !important;
+  display: none !important;
 }
 
 @media (max-width: 760px) {

--- a/assets/inject/dream-skin.css
+++ b/assets/inject/dream-skin.css
@@ -189,7 +189,7 @@ html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.
 
 html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) article,
 html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .message,
-html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="surface"] {
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) [class*="surface"]:not(:is(.composer-surface-chrome, .dream-skin-composer, .dream-skin-composer-dock, .dream-skin-composer-dock *)) {
   border: 1px solid color-mix(in srgb, var(--ds-text) 7%, transparent) !important;
   background: color-mix(in srgb, var(--ds-panel) 96%, transparent) !important;
   box-shadow: 0 10px 28px var(--ds-ink-shadow);
@@ -727,6 +727,13 @@ html.codex-dream-skin :is(.composer-surface-chrome, .dream-skin-composer)::befor
   background: linear-gradient(145deg, var(--ds-lime), var(--ds-green));
   box-shadow: 0 0 14px var(--ds-accent-glow);
   font-size: 13px;
+}
+
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .dream-skin-composer-dock:not(.dream-skin-composer) {
+  border-color: transparent !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
 }
 
 .dream-skin-home div:has(> .horizontal-scroll-fade-mask .group\/project-selector) {
@@ -3555,11 +3562,20 @@ html.codex-dream-skin[data-dream-theme="focus-capybara"] :is(.composer-surface-c
   box-shadow: 0 10px 28px rgba(48, 69, 92, .07) !important;
 }
 
-html.codex-dream-skin[data-dream-theme="focus-capybara"] :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) :where(article, .message, [class*="surface"]:not(:is(.composer-surface-chrome, .dream-skin-composer))) {
+html.codex-dream-skin[data-dream-theme="focus-capybara"] :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) :where(article, .message, [class*="surface"]:not(:is(.composer-surface-chrome, .dream-skin-composer, .dream-skin-composer-dock, .dream-skin-composer-dock *))) {
   border-color: rgba(50, 85, 125, .1) !important;
   background: #fff !important;
   color: #303235 !important;
   box-shadow: 0 8px 24px rgba(45, 66, 87, .055) !important;
+}
+
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .dream-skin-composer-dock:not(.dream-skin-composer),
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .dream-skin-composer-dock:not(.dream-skin-composer)::before,
+html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface):not(.dream-skin-home-shell) .dream-skin-composer-dock:not(.dream-skin-composer)::after {
+  border-color: transparent !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
 }
 
 @media (max-width: 760px) {

--- a/assets/inject/dream-skin.css
+++ b/assets/inject/dream-skin.css
@@ -366,6 +366,23 @@ html.codex-dream-skin :is(main.main-surface, main.dream-skin-main-surface) > hea
   font: italic 9px/1.2 "Snell Roundhand", "Segoe Print", "Comic Sans MS", cursive;
   letter-spacing: .04em;
 }
+#codex-dream-skin-chrome:not(.dream-skin-home-shell) .dream-skin-composer-stamp {
+  left: 28px;
+  right: auto;
+  bottom: 74px;
+  display: flex;
+  padding: 5px 5px 7px;
+  opacity: .92;
+  transform: rotate(-4deg);
+}
+#codex-dream-skin-chrome:not(.dream-skin-home-shell) .dream-skin-composer-stamp img {
+  width: 46px;
+  height: 46px;
+}
+#codex-dream-skin-chrome:not(.dream-skin-home-shell) .dream-skin-composer-stamp span {
+  max-width: 64px;
+  font-size: 8px;
+}
 
 /* Corner stickers. */
 .dream-skin-corner {
@@ -1590,6 +1607,10 @@ html.codex-dream-skin--minimal-focus .dream-skin-orbit,
 html.codex-dream-skin--minimal-focus .dream-skin-corner,
 html.codex-dream-skin--minimal-focus .dream-skin-washi,
 html.codex-dream-skin--minimal-focus .dream-skin-composer-stamp { display: none !important; }
+
+#codex-dream-skin-chrome:not(.dream-skin-home-shell) .dream-skin-composer-stamp {
+  display: flex !important;
+}
 
 html.codex-dream-skin--minimal-focus .dream-skin-home > div:first-child > div:first-child > div:first-child > div:first-child > div:first-child {
   width: 78% !important;

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -845,6 +845,7 @@
     document.querySelectorAll(".dream-skin-home-shell").forEach((node) => node.classList.remove("dream-skin-home-shell"));
     document.querySelectorAll(".dream-skin-main-surface").forEach((node) => node.classList.remove("dream-skin-main-surface"));
     document.querySelectorAll(".dream-skin-composer").forEach((node) => node.classList.remove("dream-skin-composer"));
+    document.querySelectorAll(".dream-skin-composer-dock").forEach((node) => node.classList.remove("dream-skin-composer-dock"));
     document.querySelectorAll(".dream-skin-role-main").forEach((node) => node.classList.remove("dream-skin-role-main"));
     document.getElementById(MOONLIT_WELCOME_ID)?.remove();
     document.getElementById(BLUE_WINDOW_HOME_ID)?.remove();
@@ -964,12 +965,22 @@
     if (mainContentSurface && mainContentSurface !== shellMain) {
       mainContentSurface.classList.add("dream-skin-role-main");
     }
+    const composerDock = shellMain?.querySelector('[class*="_ComposerLayoutRoot_"]') || null;
     const composerRoot =
       document.querySelector(".composer-surface-chrome") ||
-      shellMain?.querySelector('[class*="_ComposerLayoutRoot_"]') ||
-      shellMain?.querySelector('.ProseMirror')?.closest('[class*="_Composer"]') ||
-      shellMain?.querySelector('[contenteditable="true"]')?.closest('[class*="_Composer"]');
+      shellMain?.querySelector('.ProseMirror')?.closest('[class*="_Composer"]:not([class*="_ComposerLayoutRoot_"])') ||
+      shellMain?.querySelector('[contenteditable="true"]')?.closest('[class*="_Composer"]:not([class*="_ComposerLayoutRoot_"])') ||
+      composerDock;
     if (composerRoot instanceof HTMLElement) composerRoot.classList.add("dream-skin-composer");
+    if (composerDock instanceof HTMLElement && composerDock !== composerRoot) {
+      composerDock.classList.add("dream-skin-composer-dock");
+    }
+    if (composerRoot instanceof HTMLElement) {
+      let depth = 0;
+      for (let node = composerRoot.parentElement; node && node !== shellMain && depth < 3; node = node.parentElement, depth += 1) {
+        node.classList.add("dream-skin-composer-dock");
+      }
+    }
 
     for (const candidate of document.querySelectorAll('[role="main"].dream-skin-home, .dream-skin-role-main.dream-skin-home')) {
       if (candidate !== layoutHome) candidate.classList.remove("dream-skin-home");

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -973,6 +973,7 @@
       composerDock;
     if (composerRoot instanceof HTMLElement) composerRoot.classList.add("dream-skin-composer");
     if (composerDock instanceof HTMLElement && composerDock !== composerRoot) {
+      composerDock.classList.remove("dream-skin-composer");
       composerDock.classList.add("dream-skin-composer-dock");
     }
     if (composerRoot instanceof HTMLElement) {
@@ -980,6 +981,9 @@
       for (let node = composerRoot.parentElement; node && node !== shellMain && depth < 3; node = node.parentElement, depth += 1) {
         node.classList.add("dream-skin-composer-dock");
       }
+    }
+    if (composerDock instanceof HTMLElement && composerDock !== composerRoot) {
+      composerDock.classList.remove("dream-skin-composer");
     }
 
     for (const candidate of document.querySelectorAll('[role="main"].dream-skin-home, .dream-skin-role-main.dream-skin-home')) {

--- a/electron/engine/constants.ts
+++ b/electron/engine/constants.ts
@@ -4,7 +4,7 @@
  */
 
 /** Bumped whenever the injected payload format changes. */
-export const SKIN_VERSION = "1.2.3";
+export const SKIN_VERSION = "1.2.4";
 
 export const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
 

--- a/electron/engine/constants.ts
+++ b/electron/engine/constants.ts
@@ -4,7 +4,7 @@
  */
 
 /** Bumped whenever the injected payload format changes. */
-export const SKIN_VERSION = "1.2.0";
+export const SKIN_VERSION = "1.2.2";
 
 export const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
 

--- a/electron/engine/constants.ts
+++ b/electron/engine/constants.ts
@@ -4,7 +4,7 @@
  */
 
 /** Bumped whenever the injected payload format changes. */
-export const SKIN_VERSION = "1.2.2";
+export const SKIN_VERSION = "1.2.3";
 
 export const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
 

--- a/electron/engine/verify.ts
+++ b/electron/engine/verify.ts
@@ -86,7 +86,10 @@ export async function verifySession(session: CdpSession): Promise<VerifyResult> 
       const value = box(node);
       return Boolean(value?.visible && node.getClientRects().length > 0);
     };
-    const shellMain = document.querySelector('main.main-surface') ?? document.querySelector('main');
+    const shellMain = document.querySelector('main.main-surface') ??
+      document.querySelector('main.dream-skin-main-surface') ??
+      document.querySelector('main[class*="_MainContentSurface_"]') ??
+      document.querySelector('main');
     const homeCandidates = shellMain
       ? [
           ...(shellMain.matches('[role="main"]') ? [shellMain] : []),
@@ -104,7 +107,8 @@ export async function verifySession(session: CdpSession): Promise<VerifyResult> 
         visible(candidate.querySelector('.group\\\\/home-suggestions'));
       return visible(candidate) && hasHomeContent && !hasVisibleTaskContent;
     }) ?? null;
-    const home = document.querySelector('[role="main"].dream-skin-home');
+    const home = document.querySelector('[role="main"].dream-skin-home') ??
+      document.querySelector('.dream-skin-role-main.dream-skin-home');
     const blueWindowHome = home?.querySelector('#codex-dream-skin-blue-window-home') ?? null;
     const suggestions = blueWindowHome?.querySelector('.blue-window-home__quick-actions') ??
       home?.querySelector('.group\\\\/home-suggestions') ?? null;
@@ -115,7 +119,10 @@ export async function verifySession(session: CdpSession): Promise<VerifyResult> 
     const projectButton = box(blueWindowHome?.querySelector('[data-project-target]')) ??
       box(home?.querySelector('.group\\\\/project-selector > button'));
     const composer = box(blueWindowHome?.querySelector('.blue-window-home__composer')) ??
-      box(document.querySelector('.composer-surface-chrome'));
+      box(document.querySelector('.composer-surface-chrome')) ??
+      box(document.querySelector('.dream-skin-composer')) ??
+      box(document.querySelector('[class*="_ComposerLayoutRoot_"]')) ??
+      box(document.querySelector('.ProseMirror')?.closest('[class]'));
     const sidebar = box(document.querySelector('aside.app-shell-left-panel'));
     const chrome = document.getElementById('codex-dream-skin-chrome');
     const result = {


### PR DESCRIPTION
## Summary
- expand Codex shell verification selectors for current hashed DOM classes
- detect injected home/composer markers during verification
- treat the current ComposerLayoutRoot as a transparent dock, and style ComposerLayoutFooter as the actual input card, so task pages no longer show the extra white bottom frame
- show a compact artwork stamp on task pages so applied themes are visibly reflected
- bump the injected skin payload version to 1.2.4

## Root cause
The installed release still relied on legacy Codex selectors such as `main.main-surface` and `.composer-surface-chrome`. Current Codex desktop builds use hashed shell classes like `_MainContentSurface_` and `_ComposerLayoutRoot_`. In the current DOM, `_ComposerLayoutRoot_` is an outer composer dock while `_ComposerLayoutFooter_` is the actual input card, so styling the root directly left a large white frame behind the real input area.

## Validation
- `npm run build`
- `esbuild electron/engine/cdp.test.ts --bundle --platform=node --format=esm --outfile=tmp/tests/cdp.test.mjs && /usr/local/bin/node --test tmp/tests/cdp.test.mjs`
- live CDP re-injection on port `9341` showed `__CODEX_DREAM_SKIN_STATE__.version = 1.2.4`, verification `pass = true`, `_ComposerLayoutRoot_` transparent, and `_ComposerLayoutFooter_` as `.dream-skin-composer`
